### PR TITLE
Integrate Detekt Compose rules & enable type-resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ This project is built with the following technologies:
 *   **Coil**: For image loading.
 *   **Timber**: For logging.
 *   **Quality Tools**:
-   *   **Detekt & Spotless**: For code quality & code style.
-   *   **Custom Lint Rules**: To enforce code guidelines.
-   *   **Danger**: For giving PR insight and review niceties
+    *   **Detekt & Spotless**: For code quality & code style.
+    *   **Custom Lint Rules**: To enforce code guidelines.
+    *   **Danger**: For giving PR insight and review niceties
 
    </td>
    <td>
@@ -169,6 +169,12 @@ To automatically format the code, you can run the following command:
 ```
 
 It is recommended to run this command before pushing any changes to the repository.
+
+### Plugins
+Extra specialized tools has also been added for Jetpack Compose:
+
+*   **[Compose Rules for Detekt](https://mrmans0n.github.io/compose-rules/detekt/)**
+*   **[Compose Rules for Lints](https://slackhq.github.io/compose-lints/)**
 
 ## 🤖 CI/CD
 

--- a/config/build-logic/convention/src/main/kotlin/CodeQualityConventionPlugin.kt
+++ b/config/build-logic/convention/src/main/kotlin/CodeQualityConventionPlugin.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 
 /**
@@ -42,19 +43,20 @@ class CodeQualityConventionPlugin : Plugin<Project> {
                 buildUponDefaultConfig = true
             }
 
+            dependencies {
+                "detektPlugins"(libs.findLibrary("detekt-compose").get())
+            }
+
             /**
              * This task is used to run all the code quality checks in one go (Spotless, Lint and Detekt).
              *
-             * Lint is only available for Android modules, so it is added conditionally.
              * It can be run by executing `./gradlew codeQualityCheck`
              */
             tasks.register("codeQualityCheck") {
                 group = "verification"
                 description = "Runs Spotless, Lint and Detekt"
 
-                dependsOn("spotlessCheck", "detekt")
-
-                project.tasks.findByName("lint")?.let { dependsOn(it) }
+                dependsOn("spotlessCheck", "detektDebug", "lintRelease")
             }
         }
     }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -349,7 +349,7 @@ naming:
     rootPackage: ''
     requireRootInDeclaration: false
   LambdaParameterNaming:
-    active: false
+    active: true
     parameterPattern: '[a-z][A-Za-z0-9]*|_'
   MatchingDeclarationName:
     active: true
@@ -371,7 +371,7 @@ naming:
   NoNameShadowing:
     active: true
   NonBooleanPropertyPrefixedWithIs:
-    active: false
+    active: true
   ObjectPropertyNaming:
     active: true
     constantPattern: '[A-Za-z][_A-Za-z0-9]*'
@@ -422,9 +422,9 @@ potential-bugs:
     forbiddenTypePatterns:
       - 'kotlin.String'
   CastNullableToNonNullableType:
-    active: false
+    active: true
   CastToNullableType:
-    active: false
+    active: true
   Deprecation:
     active: false
   DontDowncastCollectionTypes:
@@ -441,7 +441,7 @@ potential-bugs:
       - 'java.util.LinkedHashMap'
       - 'java.util.HashMap'
   ElseCaseInsteadOfExhaustiveWhen:
-    active: false
+    active: true
     ignoredSubjectTypes: []
   EqualsAlwaysReturnsTrueOrFalse:
     active: true
@@ -472,7 +472,7 @@ potential-bugs:
   ImplicitDefaultLocale:
     active: true
   ImplicitUnitReturnType:
-    active: false
+    active: true
     allowExplicitReturnType: true
   InvalidRange:
     active: true
@@ -498,7 +498,7 @@ potential-bugs:
   UnconditionalJumpStatementInLoop:
     active: false
   UnnecessaryNotNullCheck:
-    active: false
+    active: true
   UnnecessaryNotNullOperator:
     active: true
   UnnecessarySafeCall:
@@ -546,12 +546,12 @@ style:
       - 'to'
     allowOperators: false
   DataClassShouldBeImmutable:
-    active: false
+    active: true
   DestructuringDeclarationWithTooManyEntries:
     active: true
     maxDestructuringEntries: 3
   DoubleNegativeLambda:
-    active: false
+    active: true
     negativeFunctions:
       - reason: 'Use `takeIf` instead.'
         value: 'takeUnless'
@@ -749,7 +749,7 @@ style:
   UntilInsteadOfRangeTo:
     active: false
   UnusedImports:
-    active: false
+    active: true
   UnusedParameter:
     active: true
     allowedNames: 'ignored|expected'
@@ -805,3 +805,130 @@ style:
     active: true
     excludeImports:
       - 'java.util.*'
+
+Compose:
+  ComposableAnnotationNaming:
+    active: true
+  ComposableNaming:
+    active: true
+    # -- You can optionally disable the checks in this rule for regex matches against the composable name (e.g. molecule presenters)
+    # allowedComposableFunctionNames: .*Presenter,.*MoleculePresenter
+  ComposableParamOrder:
+    active: true
+    # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
+    # treatAsLambda: MyLambdaType
+  CompositionLocalAllowlist:
+    active: true
+    allowedCompositionLocals: LocalColors
+  CompositionLocalNaming:
+    active: true
+  ContentEmitterReturningValues:
+    active: true
+    # -- You can optionally add your own composables here
+    # contentEmitters: MyComposable,MyOtherComposable
+  ContentTrailingLambda:
+    active: true
+    # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
+    # treatAsLambda: MyLambdaType
+    # -- You can optionally have a list of types to be treated as composable lambdas (e.g. typedefs or fun interfaces not picked up automatically).
+    # -- The difference with treatAsLambda is that those need `@Composable` MyLambdaType in the definition, while these won't.
+    # treatAsComposableLambda: MyComposableLambdaType
+  ContentSlotReused:
+    active: true
+    # -- You can optionally have a list of types to be treated as composable lambdas (e.g. typedefs or fun interfaces not picked up automatically).
+    # -- The difference with treatAsLambda is that those need `@Composable` MyLambdaType in the definition, while these won't.
+    # treatAsComposableLambda: MyComposableLambdaType
+  DefaultsVisibility:
+    active: true
+  LambdaParameterEventTrailing:
+    active: true
+    # -- You can optionally add your own composables here
+    # contentEmitters: MyComposable,MyOtherComposable
+    # -- You can add composables here that you don't want to count as content emitters (e.g. custom dialogs or modals)
+    # contentEmittersDenylist: MyNonEmitterComposable
+  LambdaParameterInRestartableEffect:
+    active: true
+    # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
+    # treatAsLambda: MyLambdaType
+  Material2:
+    active: true
+    # -- You can optionally allow parts of it, if you are in the middle of a migration.
+    # allowedFromM2: icons.Icons,TopAppBar
+  ModifierClickableOrder:
+    active: true
+    # -- You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
+  ModifierComposed:
+    active: true
+    # -- You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
+  ModifierMissing:
+    active: true
+    # -- You can optionally control the visibility of which composables to check for here
+    # -- Possible values are: `only_public`, `public_and_internal` and `all` (default is `only_public`)
+    # checkModifiersForVisibility: only_public
+    # -- You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
+    # -- You can suppress this check in functions annotated with these annotations
+    # ignoreAnnotated: ['Potato', 'Banana']
+  ModifierNaming:
+    active: true
+    # -- You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
+  ModifierNotUsedAtRoot:
+    active: true
+    # -- You can optionally add your own composables here
+    # contentEmitters: MyComposable,MyOtherComposable
+    # -- You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
+  ModifierReused:
+    active: true
+    # -- You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
+  ModifierWithoutDefault:
+    active: true
+  MultipleEmitters:
+    active: true
+    # -- You can optionally add your own composables here that will count as content emitters
+    # contentEmitters: MyComposable,MyOtherComposable
+    # -- You can add composables here that you don't want to count as content emitters (e.g. custom dialogs or modals)
+    # contentEmittersDenylist: MyNonEmitterComposable
+  MutableParams:
+    active: true
+  MutableStateAutoboxing:
+    active: true
+  MutableStateParam:
+    active: true
+  ParameterNaming:
+    active: true
+    # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
+    # treatAsLambda: MyLambdaType
+    # -- You can optionally add your allowed lambda names (e.g., usages from the past found in the official Compose code)
+    # allowedLambdaParameterNames: onSizeChanged, onGloballyPositioned
+  PreviewAnnotationNaming:
+    active: false
+  PreviewNaming:
+    active: false # Opt-in, disabled by default.
+    # -- You can optionally configure the naming strategy for previews.
+    # -- Possible values are: `suffix`, `prefix`, `anywhere`. By default, it will be `suffix`.
+    # previewNamingStrategy: suffix
+  PreviewPublic:
+    active: true
+  RememberMissing:
+    active: true
+  RememberContentMissing:
+    active: true
+  UnstableCollections:
+    active: true
+  ViewModelForwarding:
+    active: true
+    # -- You can optionally use this rule on things other than types ending in "ViewModel" or "Presenter" (which are the defaults). You can add your own via a regex here:
+    # allowedStateHolderNames: .*ViewModel,.*Presenter
+    # -- You can optionally add an allowlist for Composable names that won't be affected by this rule
+    # allowedForwarding: .*Content,.*FancyStuff
+    # -- You can optionally add an allowlist for ViewModel/StateHolder names that won't be affected by this rule
+    # allowedForwardingOfTypes: PotatoViewModel,(Apple|Banana)ViewModel,.*FancyViewModel
+  ViewModelInjection:
+    active: true
+    # -- You can optionally add your own ViewModel factories here
+    # viewModelFactories: hiltViewModel,potatoViewModel

--- a/core/ui/navigation/src/main/kotlin/com/github/app/core/ui/navigation/NavigationController.kt
+++ b/core/ui/navigation/src/main/kotlin/com/github/app/core/ui/navigation/NavigationController.kt
@@ -57,6 +57,7 @@ internal class NavigationControllerImpl(
         }
     }
 
+    @Suppress("InjectDispatcher")
     companion object {
         private const val COROUTINE_NAME = "NavigationControllerCoroutine"
         private val defaultScope: CoroutineScope = CoroutineScope(

--- a/core/ui/theme/src/main/kotlin/com/github/app/core/ui/theme/GithubAppTheme.kt
+++ b/core/ui/theme/src/main/kotlin/com/github/app/core/ui/theme/GithubAppTheme.kt
@@ -1,13 +1,11 @@
 package com.github.app.core.ui.theme
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.compositionLocalOf
 
 private val LightColorScheme = lightColorScheme(
     primary = lightGithubAppColors.brandPrimary,
@@ -41,7 +39,6 @@ fun GithubAppTheme(
 
     CompositionLocalProvider(
         LocalColors provides githubAppColors,
-        LocalStatusBarTheme provides StatusBarTheme.DEFAULT,
     ) {
         MaterialTheme(
             colorScheme = materialColorScheme,
@@ -50,12 +47,3 @@ fun GithubAppTheme(
         )
     }
 }
-
-enum class StatusBarTheme {
-    DEFAULT,
-    DARK,
-    LIGHT,
-}
-
-@SuppressLint("ComposeCompositionLocalUsage")
-val LocalStatusBarTheme = compositionLocalOf { StatusBarTheme.DEFAULT }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ kotlinSerialization = "2.2.0"
 apollo = "4.3.1"
 spotless = "7.1.0"
 detekt = "1.23.8"
+detektCompose = "0.4.26"
 gradleVersionPlugin = "0.52.0"
 # Ktlint version is used by spotless, latest -> https://github.com/pinterest/ktlint
 ktlint = "1.7.0"
@@ -69,8 +70,7 @@ koin = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose-viewmodel-navigation = { module = "io.insert-koin:koin-androidx-compose-navigation", version.ref = "koin" }
 spotless-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
-kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
-kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+detekt-compose = { module = "io.nlopez.compose.rules:detekt", version.ref = "detektCompose" }
 
 # Lint
 lint-api = { group = "com.android.tools.lint", name = "lint-api", version.ref = "androidTools" }
@@ -87,6 +87,8 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junitBom" }
 junit-jupiter-core = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
@@ -101,10 +103,9 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 gradle-version = { id = "com.github.ben-manes.versions", version.ref = "gradleVersionPlugin" }
 
-
 # Those are the Convention Plugins defined by the project in `/tools/build-logic:convention`.
 convention-config = { id = "githubapp.convention.config" }
 convention-dependencies = { id = "githubapp.convention.dependencies" }
 convention-compose = { id = "githubapp.convention.compose" }
 convention-ui-module = { id = "githubapp.convention.ui.module" }
-convention-code-quality = { id = "githubapp.convention.code.quality"}
+convention-code-quality = { id = "githubapp.convention.code.quality" }

--- a/ui/repo/src/main/kotlin/com/github/app/ui/repo/compose/component/button/FilterButtons.kt
+++ b/ui/repo/src/main/kotlin/com/github/app/ui/repo/compose/component/button/FilterButtons.kt
@@ -13,8 +13,8 @@ import kotlinx.collections.immutable.ImmutableList
 @Composable
 fun RepositoryFilterButtons(
     filterButtons: ImmutableList<FilterButtonViewState>,
-    modifier: Modifier = Modifier,
     onFilterButtonClick: (FilterButtonViewState) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     SingleChoiceSegmentedButtonRow(modifier) {
         filterButtons.forEachIndexed { index, filterButton ->

--- a/ui/repo/src/main/kotlin/com/github/app/ui/repo/screen/RepositoriesScreen.kt
+++ b/ui/repo/src/main/kotlin/com/github/app/ui/repo/screen/RepositoriesScreen.kt
@@ -128,8 +128,8 @@ private fun StateContent(
 private fun RepositoriesContent(
     viewState: State<RepositoriesScreenViewState>,
     onFilterButtonClick: (FilterButtonViewState) -> Unit,
-    modifier: Modifier = Modifier,
     onClickRepository: (RepositoryViewState) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val isVisible by viewState.rememberStateValue { repositories.isNotEmpty() }
 


### PR DESCRIPTION
This PR updates `CodeQualityConventionPlugin` to include [Detekt Compose](https://mrmans0n.github.io/compose-rules/)

Also, it runs the `codeQualityCheck` with `detektDebug` to enable type resolution. 